### PR TITLE
fix the wrong link for EnTK's documentation

### DIFF
--- a/entk/index.html
+++ b/entk/index.html
@@ -49,7 +49,7 @@
                 					<li><a href="./basic_example.html">Basic Example</a></li>
                 					<li><a href="./quick_start.html">Getting Started</a></li>
                 					<li><a href="./index.html">More Info</a></li>
-                					<li><a href="http://radicalensemblemd.readthedocs.io/en/latest/">Documentation</a></li>
+                					<li><a href="https://radicalentk.readthedocs.io/en/latest/index.html">Documentation</a></li>
                 					<li><a href="https://github.com/radical-cybertools/radical.ensemblemd">Github Project</a></li>
               				</ul>
 				</li>


### PR DESCRIPTION
Found that the link for EnTK's documentation points to a 404 page. So just fix the link.