### PR TITLE
replace broken links and redirect to rtd

### DIFF
--- a/entk/basic_example.html
+++ b/entk/basic_example.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 	<head>
+		<meta http-equiv = "refresh" content = "0; url = https://radicalentk.readthedocs.io/en/latest/examples.html" />
 		<meta charset="utf-8">
 		<meta http-equiv="X-UA-Compatible" content="IE=edge">
 		<meta name="viewport" content="width=device-width, initial-scale=1">

--- a/entk/quick_start.html
+++ b/entk/quick_start.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 	<head>
+		<meta http-equiv = "refresh" content = "0; url = https://radicalentk.readthedocs.io/en/latest/user_guide/get_started.html" />
 		<meta charset="utf-8">
 		<meta http-equiv="X-UA-Compatible" content="IE=edge">
 		<meta name="viewport" content="width=device-width, initial-scale=1">

--- a/index.html
+++ b/index.html
@@ -101,9 +101,9 @@ RADICAL Cybertools is supported by NSF ACI <a href="http://www.nsf.gov/awardsear
                     </p>
                     <p><a class="btn btn-saga" role="button" href="./saga-python/index.html">
                     More Info</a>
-                    <a class="btn btn-saga" role="button" href="http://saga-python.readthedocs.org/en/latest">
+		    <a class="btn btn-saga" role="button" href="https://radicalsaga.readthedocs.io/">
                     Documentation</a>
-                       <a class="btn btn-saga" role="button" href="https://github.com/saga-project/SAGA-Python">
+		    <a class="btn btn-saga" role="button" href="https://github.com/radical-cybertools/radical.saga">
                        Github Project </a></p>
                 </div>
                 <div class="col-lg-4 col-sm-pull-8 col-sm-6">
@@ -129,7 +129,7 @@ RADICAL Cybertools is supported by NSF ACI <a href="http://www.nsf.gov/awardsear
                       <a class="btn btn-pilot" role="button" href="./radical-pilot/basic_example.html">Basic Example</a>
                       <a class="btn btn-pilot" role="button" href="./radical-pilot/quick_start.html">Getting Started</a>
                       <a class="btn btn-pilot" role="button" href="./radical-pilot/index.html">More Info</a>
-                      <a class="btn btn-pilot" role="button" href="http://radicalpilot.readthedocs.org/en/latest">Documentation</a>
+                      <a class="btn btn-pilot" role="button" href="http://radicalpilot.readthedocs.org/">Documentation</a>
                       <a class="btn btn-pilot" role="button" href="https://github.com/radical-cybertools/radical.pilot">Github Project</a>
                     </p>                
 
@@ -155,11 +155,11 @@ RADICAL Cybertools is supported by NSF ACI <a href="http://www.nsf.gov/awardsear
                     Ensemble Toolkit provides a simple way to develop applications comprised of multiple tasks and which adhere to pre-defined patterns. The tool comes predefined with common execution patterns so users can quickly adapt the toolkit to their needs; it is possible to define more complex execution patterns. By building upon RADICAL-Pilot, the Ensemble Toolkit can take advantage of flexible and scalable resource management techniques.
                     </p>
                       <p>
-                      <a class="btn btn-enmd" role="button" href="./entk/basic_example.html">Basic Example</a>
-                      <a class="btn btn-enmd" role="button" href="./entk/quick_start.html">Getting Started</a>
+                      <a class="btn btn-enmd" role="button" href="https://radicalentk.readthedocs.io/en/latest/examples.html">Basic Example</a>
+                      <a class="btn btn-enmd" role="button" href="https://radicalentk.readthedocs.io/en/latest/user_guide/get_started.html">Getting Started</a>
                       <a class="btn btn-enmd" role="button" href="./entk/index.html">More Info</a>
-                      <a class="btn btn-enmd" role="button" href="http://radicalensemblemd.readthedocs.org/en/latest/">Documentation</a>
-                      <a class="btn btn-enmd" role="button" href="https://github.com/radical-cybertools/radical.ensemblemd">Github Project </a>
+                      <a class="btn btn-enmd" role="button" href="https://radicalentk.readthedocs.io/">Documentation</a>
+                      <a class="btn btn-enmd" role="button" href="https://github.com/radical-cybertools/radical.entk">Github Project </a>
                     </p>   
                 </div>
                 <div class="col-lg-4 col-sm-pull-8 col-sm-6">

--- a/radical-pilot/basic_example.html
+++ b/radical-pilot/basic_example.html
@@ -49,7 +49,7 @@
                 <li><a href="./basic_example.html">Basic Example</a></li>
                 <li><a href="./quick_start.html">Getting Started</a></li>
                 <li><a href="./index.html">More Info</a></li>
-                <li><a href="http://radicalpilot.readthedocs.org/en/latest">Documentation</a></li>
+                <li><a href="http://radicalpilot.readthedocs.org/">Documentation</a></li>
                 <li><a href="https://github.com/radical-cybertools/radical.pilot">Github Project</a></li>
               </ul>
             </li>
@@ -192,7 +192,7 @@ function myTimeout10() {
 <div class="text_cell_render border-box-sizing rendered_html">
 <h1 id="RADICAL-Pilot-Tutorial">Basic User Guide<a class="anchor-link" href="#RADICAL-Pilot-Tutorial"></a></h1>
 
-<h2 id="1-RADICAL-Pilot-Setup">1 RADICAL-Pilot Setup<a class="anchor-link" href="#1-RADICAL-Pilot-Setup"></a></h2><p>Documentation: <a href="http://radicalpilot.readthedocs.org/en/latest/machconf.html#preconfigured-resources">http://radicalpilot.readthedocs.org/en/latest/machconf.html#preconfigured-resources</a></p>
+<h2 id="1-RADICAL-Pilot-Setup">1 RADICAL-Pilot Setup<a class="anchor-link" href="#1-RADICAL-Pilot-Setup"></a></h2><p>Documentation: <a href="http://radicalpilot.readthedocs.org/en/stable/machconf.html#preconfigured-resources">http://radicalpilot.readthedocs.org/en/stable/machconf.html#preconfigured-resources</a></p>
 <p>First, we will import the necessary dependencies.</p>
 
 </div>

--- a/radical-pilot/index.html
+++ b/radical-pilot/index.html
@@ -49,7 +49,7 @@
                 <li><a href="./basic_example.html">Basic Example</a></li>
                 <li><a href="./quick_start.html">Getting Started</a></li>
                 <li><a href="./index.html">More Info</a></li>
-                <li><a href="http://radicalpilot.readthedocs.org/en/latest">Documentation</a></li>
+                <li><a href="http://radicalpilot.readthedocs.org/">Documentation</a></li>
                 <li><a href="https://github.com/radical-cybertools/radical.pilot">Github Project</a></li>
               </ul>
             </li>

--- a/radical-pilot/quick_start.html
+++ b/radical-pilot/quick_start.html
@@ -49,7 +49,7 @@
                 <li><a href="./basic_example.html">Basic Example</a></li>
                 <li><a href="./quick_start.html">Getting Started</a></li>
                 <li><a href="./index.html">More Info</a></li>
-                <li><a href="http://radicalpilot.readthedocs.org/en/latest">Documentation</a></li>
+                <li><a href="http://radicalpilot.readthedocs.org/en/stable">Documentation</a></li>
                 <li><a href="https://github.com/radical-cybertools/radical.pilot">Github Project</a></li>
               </ul>
             </li>

--- a/saga-python/index.html
+++ b/saga-python/index.html
@@ -106,7 +106,7 @@
             <br>
    
         <p align="center">
-          <a href="http://saga-python.readthedocs.org/en/latest/" target="_blank" class=
+          <a href="https://radicalsaga.readthedocs.io/" target="_blank" class=
           "btn btn-primary btn-large smoothScroll">Documentation</a>
         </p>
 


### PR DESCRIPTION
- radical.pilot: /en/latest is replaced by /en/stable
- radical.saga: http://saga-python.readthedocs.org/ removed
- radical.entk: internal examples are unlinked, and redirected to rtd